### PR TITLE
fix: lowercase package name

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,8 @@
         "dist": true // set this to false to include "dist" folder in search results
     },
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
-    "typescript.tsc.autoDetect": "off"
+    "typescript.tsc.autoDetect": "off",
+    "cSpell.words": [
+      "protopi"
+    ]
 }

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "ProtoPI",
+  "name": "protopi",
   "displayName": "ProtoPI",
   "description": "",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "engines": {
     "vscode": "^1.89.0"
   },


### PR DESCRIPTION
## Description

- Change name property in package.json from "ProtoPI" to "protopi" to conform to npm package naming rule.
- Add "protopi" to cSpell.words workspace settings.

## Reproduction steps

Self-explanatory.

## Checklist

- [x] I've followed the [Contributing guidelines](https://github.com/oslabs-beta/.github/blob/main/docs/CONTRIBUTING.md)
- [x] I've titled my PR according to the [Conventional Commits spec](https://conventionalcommits.org)
- [ ] I've added tests that fail without this PR but pass with it
- [x] I've linted, tested, and commented my code
- [ ] I've updated documentation (if appropriate)
